### PR TITLE
fix: remove redundant arg id

### DIFF
--- a/frontend/src/services/restaurant.js
+++ b/frontend/src/services/restaurant.js
@@ -25,7 +25,7 @@ class RestaurantDataService {
     return http.delete(`/review-delete?id=${id}`, {data:{user_id: userId}});
   }
 
-  getCuisines(id) {
+  getCuisines() {
     return http.get(`/cuisines`);
   }
 


### PR DESCRIPTION
The getCuisines function has a redundant arg id.
The arg id is not required to get the list of cuisines.